### PR TITLE
Generate SSH automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ vendor/
 .terraform/
 /app/*/*
 !/app/zend/*
+/build/infrastructure/config/ssh-key*
 /config/**/*.*
 !/config/**/*.dist
 /tmp/

--- a/README.md
+++ b/README.md
@@ -72,12 +72,7 @@ Then, you need to override some values in it:
 
 - `access_key`: the access key of your AWS account
 - `secret_key`: the secret access key of your AWS account
-- `ssh_key_name`: the name of your key pair added to EC2
-- `ssh_private_key`: the file name of your private key
 - `region`: it is "eu-central-1" by default, but you should choose the closest one to your area
-
-Finally, you have to copy your private key in the "build/infrastructure/config" directory with a file name that matches
-the one defined in the `ssh_private_key` setting.
 
 Now, you are ready to go:
 

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -30,6 +30,13 @@ if [[ "$1" == "run" ]]; then
     export RESULT_ROOT_DIR
     export INFRA_ENVIRONMENT
 
+    if [[ "$INFRA_ENVIRONMENT" != "local" ]]; then
+        ssh_key_path="build/infrastructure/config/ssh-key";
+        if [[ ! -f "${ssh_key_path}" ]]; then
+          ssh-keygen -f "${ssh_key_path}" -q -N "";
+        fi
+    fi
+
     for infra_config in $PROJECT_ROOT/config/infra/$INFRA_ENVIRONMENT/*.ini; do
         source "$infra_config"
         export $(cut -d= -f1 $infra_config)

--- a/build/infrastructure/aws/variables.tf
+++ b/build/infrastructure/aws/variables.tf
@@ -8,15 +8,6 @@ variable "secret_key" {
   sensitive = true
 }
 
-variable "ssh_key_name" {
-  type = string
-}
-
-variable "ssh_private_key" {
-  type = string
-  sensitive = true
-}
-
 variable "region" {
   type = string
 }

--- a/build/infrastructure/config/aws.tfvars.dist
+++ b/build/infrastructure/config/aws.tfvars.dist
@@ -1,7 +1,5 @@
 access_key = ""
 secret_key = ""
-ssh_key_name = "ec2"
-ssh_private_key = "ec2.pem"
 region = "eu-central-1"
 
 image_user = "ec2-user"


### PR DESCRIPTION
Rather than having to create an SSH key on AWS, and manage it yourself (storing the private key, adding the name to the config), `benchmark.sh` can generate its own key, and use Terraform to temporarily upload the public key (it's removed at the end of the process).

I should note that `ssh-keygen` doesn't specify the key type and/or size (the defaults are usually safe enough)... and it might be safer to delete the key files at the end of `benchmark.sh` so new keys are created each time.