### PR TITLE
Quick check to ensure there are active tests

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -50,6 +50,8 @@ if [[ "$1" == "run" ]]; then
         export "PHP_COMMITS_$PHP_ID=$(git -C "$PHP_SOURCE_PATH" rev-parse HEAD)"
     done
 
+    ls ./config/test/*.ini > /dev/null # Exit early if no tests are available, ref `set -e`
+
     if [[ "$INFRA_ENVIRONMENT" == "local" ]]; then
         $PROJECT_ROOT/bin/setup.sh
     fi


### PR DESCRIPTION
Might be better to use something more explicit, like `TEST_COUNT` in `benchmark.sh`,  but this makes sure that there is at least one `.ini` file in the `./config/test/` folder.

I forgot to do this the first time, and it only became apparent after the server had been setup and PHP had been compiled.