### PR TITLE
unify benchmark url

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The framework is heavily inspired by Intel's work from quite a few years ago: [h
 
 ## Results
 
-You can find the benchmark results [here](https://kocsismate.github.io/php-version-benchmarks/index.html).
+You can find the [benchmark results here](https://kocsismate.github.io/php-version-benchmarks/).
 
 ## Install
 


### PR DESCRIPTION
use the same url as in the github projects title