### PR TITLE
Set locale to avoid issues with number formatting and parsing

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+export LC_ALL=C
 export PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [[ "$1" == "run" ]]; then


### PR DESCRIPTION
Depending on the locale, `printf` could format numbers in a way that will not work later in the program.

This fixes the following error on some machine:

```
bin/benchmark.sh: line 17: printf: 0.233922: invalid number
```

Line 17: https://github.com/kocsismate/php-version-benchmarks/blob/d8841911a05fbdd3f68b89fac77cbb384b98785e/bin/benchmark.sh#L17